### PR TITLE
Fix configuration files for examples

### DIFF
--- a/examples/hacker/p01/opt.conf
+++ b/examples/hacker/p01/opt.conf
@@ -4,9 +4,7 @@
 
 --target bins/_Z3p01i.s # Path to the function to optimize
 --init previous # Begin search from synthesis result
---current synth_result.s
---best_yet synth_result.s
---best_correct bins/_Z3p01i.s
+--previous synth_result.s
 
 --def_in "{ %rbp %rsp %rdi }" # The registers that are defined on entry to the target
 --live_out "{ %rax }" # The registers that are live on exit from the target
@@ -19,9 +17,7 @@
 --misalign_penalty 1 # Penalty for results that appear in the wrong location
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
--k 100
-
---perf latency # Measure performance by summing instruction latencies
+--cost "100*correctness + latency"
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -36,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 1000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p01/synth.conf
+++ b/examples/hacker/p01/synth.conf
@@ -17,7 +17,7 @@
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
 
---perf none # Measure performance by summing instruction latencies
+--cost "correctness" # Care only about correctness, no latencies
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -32,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 10000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p02/opt.conf
+++ b/examples/hacker/p02/opt.conf
@@ -4,9 +4,7 @@
 
 --target bins/_Z3p02i.s # Path to the function to optimize
 --init previous # Begin search from synthesis result
---current synth_result.s
---best_yet synth_result.s
---best_correct bins/_Z3p02i.s
+--previous synth_result.s
 
 --def_in "{ %rbp %rsp %rdi }" # The registers that are defined on entry to the target
 --live_out "{ %rax }" # The registers that are live on exit from the target
@@ -19,9 +17,7 @@
 --misalign_penalty 1 # Penalty for results that appear in the wrong location
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
--k 100
-
---perf latency # Measure performance by summing instruction latencies
+--cost "100*correctness + latency"
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -36,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 1000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p02/synth.conf
+++ b/examples/hacker/p02/synth.conf
@@ -17,7 +17,7 @@
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
 
---perf none # Measure performance by summing instruction latencies
+--cost "correctness" # Care only about correctness, no latencies
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -32,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 10000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p03/opt.conf
+++ b/examples/hacker/p03/opt.conf
@@ -4,9 +4,7 @@
 
 --target bins/_Z3p03i.s # Path to the function to optimize
 --init previous # Begin search from synthesis result
---current synth_result.s
---best_yet synth_result.s
---best_correct bins/_Z3p03i.s
+--previous synth_result.s
 
 --def_in "{ %rbp %rsp %rdi }" # The registers that are defined on entry to the target
 --live_out "{ %rax }" # The registers that are live on exit from the target
@@ -19,9 +17,7 @@
 --misalign_penalty 1 # Penalty for results that appear in the wrong location
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
--k 100
-
---perf latency # Measure performance by summing instruction latencies
+--cost "100*correctness + latency"
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -36,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 1000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p03/synth.conf
+++ b/examples/hacker/p03/synth.conf
@@ -17,7 +17,7 @@
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
 
---perf none # Measure performance by summing instruction latencies
+--cost "correctness" # Care only about correctness, no latencies
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -32,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 10000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p04/opt.conf
+++ b/examples/hacker/p04/opt.conf
@@ -4,9 +4,7 @@
 
 --target bins/_Z3p04i.s # Path to the function to optimize
 --init previous # Begin search from synthesis result
---current synth_result.s
---best_yet synth_result.s
---best_correct bins/_Z3p04i.s
+--previous synth_result.s
 
 --def_in "{ %rbp %rsp %rdi }" # The registers that are defined on entry to the target
 --live_out "{ %rax }" # The registers that are live on exit from the target
@@ -19,9 +17,7 @@
 --misalign_penalty 1 # Penalty for results that appear in the wrong location
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
--k 100
-
---perf latency # Measure performance by summing instruction latencies
+--cost "100*correctness + latency"
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -36,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 1000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p04/synth.conf
+++ b/examples/hacker/p04/synth.conf
@@ -17,7 +17,7 @@
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
 
---perf none # Measure performance by summing instruction latencies
+--cost "correctness" # Care only about correctness, no latencies
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -32,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 10000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p05/opt.conf
+++ b/examples/hacker/p05/opt.conf
@@ -4,9 +4,7 @@
 
 --target bins/_Z3p05i.s # Path to the function to optimize
 --init previous # Begin search from synthesis result
---current synth_result.s
---best_yet synth_result.s
---best_correct bins/_Z3p05i.s
+--previous synth_result.s
 
 --def_in "{ %rbp %rsp %rdi }" # The registers that are defined on entry to the target
 --live_out "{ %rax }" # The registers that are live on exit from the target
@@ -19,9 +17,7 @@
 --misalign_penalty 1 # Penalty for results that appear in the wrong location
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
--k 100
-
---perf latency # Measure performance by summing instruction latencies
+--cost "100*correctness + latency"
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -36,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 1000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p05/synth.conf
+++ b/examples/hacker/p05/synth.conf
@@ -17,7 +17,7 @@
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
 
---perf none # Measure performance by summing instruction latencies
+--cost "correctness" # Care only about correctness, no latencies
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -32,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 10000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p06/opt.conf
+++ b/examples/hacker/p06/opt.conf
@@ -4,9 +4,7 @@
 
 --target bins/_Z3p06i.s # Path to the function to optimize
 --init previous # Begin search from synthesis result
---current synth_result.s
---best_yet synth_result.s
---best_correct bins/_Z3p06i.s
+--previous synth_result.s
 
 --def_in "{ %rbp %rsp %rdi }" # The registers that are defined on entry to the target
 --live_out "{ %rax }" # The registers that are live on exit from the target
@@ -19,9 +17,7 @@
 --misalign_penalty 1 # Penalty for results that appear in the wrong location
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
--k 100
-
---perf latency # Measure performance by summing instruction latencies
+--cost "100*correctness + latency"
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -36,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 1000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p06/synth.conf
+++ b/examples/hacker/p06/synth.conf
@@ -17,7 +17,7 @@
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
 
---perf none # Measure performance by summing instruction latencies
+--cost "correctness" # Care only about correctness, no latencies
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -32,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 10000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p07/opt.conf
+++ b/examples/hacker/p07/opt.conf
@@ -4,9 +4,7 @@
 
 --target bins/_Z3p07i.s # Path to the function to optimize
 --init previous # Begin search from synthesis result
---current synth_result.s
---best_yet synth_result.s
---best_correct bins/_Z3p07i.s
+--previous synth_result.s
 
 --def_in "{ %rbp %rsp %rdi }" # The registers that are defined on entry to the target
 --live_out "{ %rax }" # The registers that are live on exit from the target
@@ -19,9 +17,7 @@
 --misalign_penalty 1 # Penalty for results that appear in the wrong location
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
--k 100
-
---perf latency # Measure performance by summing instruction latencies
+--cost "100*correctness + latency"
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -36,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 1000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p07/synth.conf
+++ b/examples/hacker/p07/synth.conf
@@ -17,7 +17,7 @@
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
 
---perf none # Measure performance by summing instruction latencies
+--cost "correctness" # Care only about correctness, no latencies
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -32,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 10000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p08/opt.conf
+++ b/examples/hacker/p08/opt.conf
@@ -4,9 +4,7 @@
 
 --target bins/_Z3p08i.s # Path to the function to optimize
 --init previous # Begin search from synthesis result
---current synth_result.s
---best_yet synth_result.s
---best_correct bins/_Z3p08i.s
+--previous synth_result.s
 
 --def_in "{ %rbp %rsp %rdi }" # The registers that are defined on entry to the target
 --live_out "{ %rax }" # The registers that are live on exit from the target
@@ -19,9 +17,7 @@
 --misalign_penalty 1 # Penalty for results that appear in the wrong location
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
--k 100
-
---perf latency # Measure performance by summing instruction latencies
+--cost "100*correctness + latency"
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -36,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 1000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p08/synth.conf
+++ b/examples/hacker/p08/synth.conf
@@ -17,7 +17,7 @@
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
 
---perf none # Measure performance by summing instruction latencies
+--cost "correctness" # Care only about correctness, no latencies
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -32,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 10000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p09/opt.conf
+++ b/examples/hacker/p09/opt.conf
@@ -4,9 +4,7 @@
 
 --target bins/_Z3p09i.s # Path to the function to optimize
 --init previous # Begin search from synthesis result
---current synth_result.s
---best_yet synth_result.s
---best_correct bins/_Z3p09i.s
+--previous synth_result.s
 
 --def_in "{ %rbp %rsp %rdi }" # The registers that are defined on entry to the target
 --live_out "{ %rax }" # The registers that are live on exit from the target
@@ -19,9 +17,7 @@
 --misalign_penalty 1 # Penalty for results that appear in the wrong location
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
--k 100
-
---perf latency # Measure performance by summing instruction latencies
+--cost "100*correctness + latency"
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -36,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 1000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p09/synth.conf
+++ b/examples/hacker/p09/synth.conf
@@ -17,7 +17,7 @@
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
 
---perf none # Measure performance by summing instruction latencies
+--cost "correctness" # Care only about correctness, no latencies
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -32,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 10000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p10/opt.conf
+++ b/examples/hacker/p10/opt.conf
@@ -4,9 +4,7 @@
 
 --target bins/_Z3p10ii.s # Path to the function to optimize
 --init previous # Begin search from synthesis result
---current synth_result.s
---best_yet synth_result.s
---best_correct bins/_Z3p10ii.s
+--previous synth_result.s
 
 --def_in "{ %rbp %rsp %rdi %rsi }" # The registers that are defined on entry to the target
 --live_out "{ %rax }" # The registers that are live on exit from the target
@@ -19,9 +17,7 @@
 --misalign_penalty 1 # Penalty for results that appear in the wrong location
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
--k 100
-
---perf latency # Measure performance by summing instruction latencies
+--cost "100*correctness + latency"
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 

--- a/examples/hacker/p10/synth.conf
+++ b/examples/hacker/p10/synth.conf
@@ -17,7 +17,7 @@
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
 
---perf none # Measure performance by summing instruction latencies
+--cost "correctness" # Care only about correctness, no latencies
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -32,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 10000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p11/opt.conf
+++ b/examples/hacker/p11/opt.conf
@@ -4,9 +4,7 @@
 
 --target bins/_Z3p11ii.s # Path to the function to optimize
 --init previous # Begin search from synthesis result
---current synth_result.s
---best_yet synth_result.s
---best_correct bins/_Z3p11ii.s
+--previous synth_result.s
 
 --def_in "{ %rbp %rsp %rdi %rsi }" # The registers that are defined on entry to the target
 --live_out "{ %rax }" # The registers that are live on exit from the target
@@ -19,9 +17,7 @@
 --misalign_penalty 1 # Penalty for results that appear in the wrong location
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
--k 100
-
---perf latency # Measure performance by summing instruction latencies
+--cost "100*correctness + latency"
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -36,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 1000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p11/synth.conf
+++ b/examples/hacker/p11/synth.conf
@@ -17,7 +17,7 @@
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
 
---perf none # Measure performance by summing instruction latencies
+--cost "correctness" # Care only about correctness, no latencies
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -32,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 10000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p12/opt.conf
+++ b/examples/hacker/p12/opt.conf
@@ -4,9 +4,7 @@
 
 --target bins/_Z3p12ii.s # Path to the function to optimize
 --init previous # Begin search from synthesis result
---current synth_result.s
---best_yet synth_result.s
---best_correct bins/_Z3p12ii.s
+--previous synth_result.s
 
 --def_in "{ %rbp %rsp %rdi %rsi }" # The registers that are defined on entry to the target
 --live_out "{ %rax }" # The registers that are live on exit from the target
@@ -19,9 +17,7 @@
 --misalign_penalty 1 # Penalty for results that appear in the wrong location
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
--k 100
-
---perf latency # Measure performance by summing instruction latencies
+--cost "100*correctness + latency"
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -36,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 1000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p12/synth.conf
+++ b/examples/hacker/p12/synth.conf
@@ -17,7 +17,7 @@
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
 
---perf none # Measure performance by summing instruction latencies
+--cost "correctness" # Care only about correctness, no latencies
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -32,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 10000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p13/opt.conf
+++ b/examples/hacker/p13/opt.conf
@@ -4,9 +4,7 @@
 
 --target bins/_Z3p13i.s # Path to the function to optimize
 --init previous # Begin search from synthesis result
---current synth_result.s
---best_yet synth_result.s
---best_correct bins/_Z3p13i.s
+--previous synth_result.s
 
 --def_in "{ %rbp %rsp %rdi }" # The registers that are defined on entry to the target
 --live_out "{ %rax }" # The registers that are live on exit from the target
@@ -19,9 +17,7 @@
 --misalign_penalty 1 # Penalty for results that appear in the wrong location
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
--k 100
-
---perf latency # Measure performance by summing instruction latencies
+--cost "100*correctness + latency"
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -36,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 1000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p13/synth.conf
+++ b/examples/hacker/p13/synth.conf
@@ -17,7 +17,7 @@
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
 
---perf none # Measure performance by summing instruction latencies
+--cost "correctness" # Care only about correctness, no latencies
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -32,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 10000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p14/opt.conf
+++ b/examples/hacker/p14/opt.conf
@@ -4,9 +4,7 @@
 
 --target bins/_Z3p14ii.s # Path to the function to optimize
 --init previous # Begin search from synthesis result
---current synth_result.s
---best_yet synth_result.s
---best_correct bins/_Z3p14ii.s
+--previous synth_result.s
 
 --def_in "{ %rbp %rsp %rdi %rsi }" # The registers that are defined on entry to the target
 --live_out "{ %rax }" # The registers that are live on exit from the target
@@ -19,9 +17,7 @@
 --misalign_penalty 1 # Penalty for results that appear in the wrong location
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
--k 100
-
---perf latency # Measure performance by summing instruction latencies
+--cost "100*correctness + latency"
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -36,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 1000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p14/synth.conf
+++ b/examples/hacker/p14/synth.conf
@@ -17,7 +17,7 @@
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
 
---perf none # Measure performance by summing instruction latencies
+--cost "correctness" # Care only about correctness, no latencies
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -32,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 10000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p15/opt.conf
+++ b/examples/hacker/p15/opt.conf
@@ -4,9 +4,7 @@
 
 --target bins/_Z3p15ii.s # Path to the function to optimize
 --init previous # Begin search from synthesis result
---current synth_result.s
---best_yet synth_result.s
---best_correct bins/_Z3p15ii.s
+--previous synth_result.s
 
 --def_in "{ %rbp %rsp %rdi %rsi }" # The registers that are defined on entry to the target
 --live_out "{ %rax }" # The registers that are live on exit from the target
@@ -19,9 +17,7 @@
 --misalign_penalty 1 # Penalty for results that appear in the wrong location
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
--k 100
-
---perf latency # Measure performance by summing instruction latencies
+--cost "100*correctness + latency"
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -36,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 1000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p15/synth.conf
+++ b/examples/hacker/p15/synth.conf
@@ -17,7 +17,7 @@
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
 
---perf none # Measure performance by summing instruction latencies
+--cost "correctness" # Care only about correctness, no latencies
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -32,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 10000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p16/opt.conf
+++ b/examples/hacker/p16/opt.conf
@@ -4,9 +4,7 @@
 
 --target bins/_Z3p16ii.s # Path to the function to optimize
 --init previous # Begin search from synthesis result
---current synth_result.s
---best_yet synth_result.s
---best_correct bins/_Z3p16ii.s
+--previous synth_result.s
 
 --def_in "{ %rbp %rsp %rdi %rsi }" # The registers that are defined on entry to the target
 --live_out "{ %rax }" # The registers that are live on exit from the target
@@ -19,9 +17,7 @@
 --misalign_penalty 1 # Penalty for results that appear in the wrong location
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
--k 100
-
---perf latency # Measure performance by summing instruction latencies
+--cost "100*correctness + latency"
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -36,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 1000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p16/synth.conf
+++ b/examples/hacker/p16/synth.conf
@@ -17,7 +17,7 @@
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
 
---perf none # Measure performance by summing instruction latencies
+--cost "correctness" # Care only about correctness, no latencies
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -32,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 10000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p17/opt.conf
+++ b/examples/hacker/p17/opt.conf
@@ -4,9 +4,7 @@
 
 --target bins/_Z3p17i.s # Path to the function to optimize
 --init previous # Begin search from synthesis result
---current synth_result.s
---best_yet synth_result.s
---best_correct bins/_Z3p17i.s
+--previous synth_result.s
 
 --def_in "{ %rbp %rsp %rdi }" # The registers that are defined on entry to the target
 --live_out "{ %rax }" # The registers that are live on exit from the target
@@ -19,9 +17,7 @@
 --misalign_penalty 1 # Penalty for results that appear in the wrong location
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
--k 100
-
---perf latency # Measure performance by summing instruction latencies
+--cost "100*correctness + latency"
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -36,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 1000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p17/synth.conf
+++ b/examples/hacker/p17/synth.conf
@@ -17,7 +17,7 @@
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
 
---perf none # Measure performance by summing instruction latencies
+--cost "correctness" # Care only about correctness, no latencies
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -32,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 10000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p18/opt.conf
+++ b/examples/hacker/p18/opt.conf
@@ -4,9 +4,7 @@
 
 --target bins/_Z3p18i.s # Path to the function to optimize
 --init previous # Begin search from synthesis result
---current synth_result.s
---best_yet synth_result.s
---best_correct bins/_Z3p18i.s
+--previous synth_result.s
 
 --def_in "{ %rbp %rsp %rdi }" # The registers that are defined on entry to the target
 --live_out "{ %rax }" # The registers that are live on exit from the target
@@ -19,9 +17,7 @@
 --misalign_penalty 1 # Penalty for results that appear in the wrong location
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
--k 100
-
---perf latency # Measure performance by summing instruction latencies
+--cost "100*correctness + latency"
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -36,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 1000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p18/synth.conf
+++ b/examples/hacker/p18/synth.conf
@@ -17,7 +17,7 @@
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
 
---perf none # Measure performance by summing instruction latencies
+--cost "correctness" # Care only about correctness, no latencies
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -32,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 10000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p19/opt.conf
+++ b/examples/hacker/p19/opt.conf
@@ -4,9 +4,8 @@
 
 --target bins/_Z3p19iii.s # Path to the function to optimize
 --init previous # Begin search from synthesis result
---current bins/_Z3p19iii.s
---best_yet bins/_Z3p19iii.s
---best_correct bins/_Z3p19iii.s
+--previous bins/_Z3p19iii.s
+
 
 --def_in "{ %rbp %rsp %rdi %rsi %rdx }" # The registers that are defined on entry to the target
 --live_out "{ %rax }" # The registers that are live on exit from the target
@@ -19,9 +18,7 @@
 --misalign_penalty 1 # Penalty for results that appear in the wrong location
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
--k 100
-
---perf latency # Measure performance by summing instruction latencies
+--cost "100*correctness + latency"
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -36,8 +33,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 10000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p19/synth.conf
+++ b/examples/hacker/p19/synth.conf
@@ -17,7 +17,7 @@
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
 
---perf none # Measure performance by summing instruction latencies
+--cost "correctness" # Care only about correctness, no latencies
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -32,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 10000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p20/opt.conf
+++ b/examples/hacker/p20/opt.conf
@@ -4,9 +4,7 @@
 
 --target bins/_Z3p20i.s # Path to the function to optimize
 --init previous # Begin search from synthesis result
---current bins/_Z3p20i.s
---best_yet bins/_Z3p20i.s
---best_correct bins/_Z3p20i.s
+--previous bins/_Z3p20i.s
 
 --def_in "{ %rbp %rsp %rdi }" # The registers that are defined on entry to the target
 --live_out "{ %rax }" # The registers that are live on exit from the target
@@ -19,9 +17,7 @@
 --misalign_penalty 1 # Penalty for results that appear in the wrong location
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
--k 100
-
---perf latency # Measure performance by summing instruction latencies
+--cost "100*correctness + latency"
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -36,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 10000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p20/synth.conf
+++ b/examples/hacker/p20/synth.conf
@@ -17,7 +17,7 @@
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
 
---perf none # Measure performance by summing instruction latencies
+--cost "correctness" # Care only about correctness, no latencies
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -32,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 10000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p21/opt.conf
+++ b/examples/hacker/p21/opt.conf
@@ -4,9 +4,7 @@
 
 --target bins/_Z3p21iiii.s # Path to the function to optimize
 --init previous # Begin search from synthesis result
---current synth_result.s
---best_yet synth_result.s
---best_correct bins/_Z3p21iiii.s
+--previous synth_result.s
 
 --def_in "{ %rbp %rsp %rdi %rsi %rdx %rcx }" # The registers that are defined on entry to the target
 --live_out "{ %rax }" # The registers that are live on exit from the target
@@ -19,9 +17,7 @@
 --misalign_penalty 1 # Penalty for results that appear in the wrong location
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
--k 100
-
---perf latency # Measure performance by summing instruction latencies
+--cost "100*correctness + latency"
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -36,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 1000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p21/synth.conf
+++ b/examples/hacker/p21/synth.conf
@@ -17,7 +17,7 @@
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
 
---perf none # Measure performance by summing instruction latencies
+--cost "correctness" # Care only about correctness, no latencies
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -32,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 10000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p22/opt.conf
+++ b/examples/hacker/p22/opt.conf
@@ -4,9 +4,7 @@
 
 --target bins/_Z3p22i.s # Path to the function to optimize
 --init previous # Begin search from synthesis result
---current synth_result.s
---best_yet synth_result.s
---best_correct bins/_Z3p22i.s
+--previous synth_result.s
 
 --def_in "{ %rbp %rsp %rdi }" # The registers that are defined on entry to the target
 --live_out "{ %rax }" # The registers that are live on exit from the target
@@ -19,9 +17,7 @@
 --misalign_penalty 1 # Penalty for results that appear in the wrong location
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
--k 100
-
---perf latency # Measure performance by summing instruction latencies
+--cost "100*correctness + latency"
 
 --cpu_flags "{ popcnt }" # cpuid flags to use when proposing instructions
 
@@ -36,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 1000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p22/synth.conf
+++ b/examples/hacker/p22/synth.conf
@@ -17,7 +17,7 @@
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
 
---perf none # Measure performance by summing instruction latencies
+--cost "correctness" # Care only about correctness, no latencies
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -32,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 10000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p23/opt.conf
+++ b/examples/hacker/p23/opt.conf
@@ -4,9 +4,7 @@
 
 --target bins/_Z3p23i.s # Path to the function to optimize
 --init previous # Begin search from synthesis result
---current synth_result.s
---best_yet synth_result.s
---best_correct bins/_Z3p23i.s
+--previous synth_result.s
 
 --def_in "{ %rbp %rsp %rdi }" # The registers that are defined on entry to the target
 --live_out "{ %rax }" # The registers that are live on exit from the target
@@ -19,9 +17,7 @@
 --misalign_penalty 1 # Penalty for results that appear in the wrong location
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
--k 100
-
---perf latency # Measure performance by summing instruction latencies
+--cost "100*correctness + latency"
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -36,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 1000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p23/synth.conf
+++ b/examples/hacker/p23/synth.conf
@@ -17,7 +17,7 @@
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
 
---perf none # Measure performance by summing instruction latencies
+--cost "correctness" # Care only about correctness, no latencies
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -32,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 10000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p24/opt.conf
+++ b/examples/hacker/p24/opt.conf
@@ -4,9 +4,7 @@
 
 --target bins/_Z3p24i.s # Path to the function to optimize
 --init previous # Begin search from synthesis result
---current bins/_Z3p24i.s
---best_yet bins/_Z3p24i.s
---best_correct bins/_Z3p24i.s
+--previous bins/_Z3p24i.s
 
 --def_in "{ %rbp %rsp %rdi }" # The registers that are defined on entry to the target
 --live_out "{ %rax }" # The registers that are live on exit from the target
@@ -19,9 +17,7 @@
 --misalign_penalty 1 # Penalty for results that appear in the wrong location
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
--k 100
-
---perf latency # Measure performance by summing instruction latencies
+--cost "100*correctness + latency"
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -36,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 1000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p24/synth.conf
+++ b/examples/hacker/p24/synth.conf
@@ -17,7 +17,7 @@
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
 
---perf none # Measure performance by summing instruction latencies
+--cost "correctness" # Care only about correctness, no latencies
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -32,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 10000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p25/opt.conf
+++ b/examples/hacker/p25/opt.conf
@@ -4,9 +4,7 @@
 
 --target bins/_Z3p25ii.s # Path to the function to optimize
 --init previous # Begin search from synthesis result
---current synth_result.s
---best_yet synth_result.s
---best_correct bins/_Z3p25ii.s
+--previous synth_result.s
 
 --def_in "{ %rbp %rsp %rdi %rsi }" # The registers that are defined on entry to the target
 --live_out "{ %rax }" # The registers that are live on exit from the target
@@ -19,9 +17,7 @@
 --misalign_penalty 1 # Penalty for results that appear in the wrong location
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
--k 100
-
---perf latency # Measure performance by summing instruction latencies
+--cost "100*correctness + latency"
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -36,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 1000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/hacker/p25/synth.conf
+++ b/examples/hacker/p25/synth.conf
@@ -17,7 +17,7 @@
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
 
---perf none # Measure performance by summing instruction latencies
+--cost "correctness" # Care only about correctness, no latencies
 
 --cpu_flags "{ popcnt cmov abm bmi1 bmi2 }" # cpuid flags to use when proposing instructions
 
@@ -32,8 +32,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 10000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/montmul/opt.conf
+++ b/examples/montmul/opt.conf
@@ -4,9 +4,7 @@
 
 --target bins/_Z8mont_mulmmjjm.s # Path to the function to optimize
 --init previous # Begin search from synthesis result
---current synth_result.s
---best_yet synth_result.s
---best_correct bins/_Z8mont_mulmmjjm.s
+--previous synth_result.s
 
 --def_in "{ %rdi %rsi %rdx %rcx %r8 }" # The registers that are defined on entry to the target
 --live_out "{ %rdi %r8 }" # The registers that are live on exit from the target
@@ -19,9 +17,8 @@
 --misalign_penalty 1 # Penalty for results that appear in the wrong location
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
--k 100
 
---perf latency # Measure performance by summing instruction latencies
+--cost "100*correctness+latency" # Measure performance by summing instruction latencies
 
 --cpu_flags "{ popcnt cmov }" # cpuid flags to use when proposing instructions
 
@@ -36,8 +33,9 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 10000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
+
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/montmul/synth.conf
+++ b/examples/montmul/synth.conf
@@ -17,7 +17,7 @@
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
 
---perf none # Measure performance by summing instruction latencies
+--cost correctness # Measure performance by summing instruction latencies
 
 --cpu_flags "{ popcnt cmov }" # cpuid flags to use when proposing instructions
 

--- a/examples/saxpy/opt.conf
+++ b/examples/saxpy/opt.conf
@@ -4,9 +4,7 @@
 
 --target bins/_Z5saxpyjPjS_i.s # Path to the function to optimize
 --init previous # Begin search from synthesis result
---current synth_result.s
---best_yet synth_result.s
---best_correct bins/_Z5saxpyjPjS_i.s
+--previous synth_result.s
 
 --def_in "{ %rbp %rsp %rdi %rsi %rdx %rcx }" # The registers that are defined on entry to the target
 --live_out "{ }" # The registers that are live on exit from the target
@@ -21,9 +19,8 @@
 --reduction sum # Method for summing errors across testcases
 --sig_penalty 9999 # Score to assign to rewrites that produce non-zero signals
 --relax_mem
--k 100
 
---perf latency # Measure performance by summing instruction latencies
+--cost "100*correctness + latency" # Measure performance by summing instruction latencies
 
 --cpu_flags "{ sse sse2 ssse3 pni sse4_1 sse4_2 }" # cpuid flags to use when proposing instructions
 --mem_ops "{ (%rsi,%rcx,4) (%rdx,%rcx,4) }" 
@@ -39,8 +36,8 @@
 --initial_instruction_number 32 # The maximum number of instruction allowed in a rewrite
 
 --statistics_interval 1000000 # Print statistics every 1m proposals
---timeout 1000000 # Propose 1m modifications before giving up
---timeout_action testcase # Try adding a new testcase from the testset when search times out
---timeout_cycles 16 # Timeout up to 16 times before giving up
+--timeout_iterations 16000000 # Propose 1m modifications before giving up
+--failed_verification_action add_counterexample # Try adding a new testcase from the testset when search times out
+--cycle_timeout 1000000 # Timeout up to 16 times before giving up
 
 --strategy hold_out # Verify results using a larger hold out testcase set

--- a/examples/saxpy/synth.conf
+++ b/examples/saxpy/synth.conf
@@ -20,7 +20,7 @@
 --relax_mem # Allow correct values in incorrect locations
 --blocked_heap_opt # Use optimized version of relax_mem that assumes 128-bit writes to heap
 
---perf none # Measure performance by summing instruction latencies
+--cost "correctness" # Measure performance by summing instruction latencies
 
 --cpu_flags "{ sse sse2 ssse3 pni sse4_1 sse4_2 }" # cpuid flags to use when proposing instructions
 --mem_ops "{ (%rdx,%rcx,4) (%rsi,%rcx,4) }" 


### PR DESCRIPTION
Hello,

Trying to make the examples work, a bunch of them were failing when trying to run them using the provided Makefile.
The cause was some changes in the accepted command-line arguments.
Change in the cost-function handling: ce7fa82cd16c31722016e0683a3fd5a514543b67
Change in the timeout code: 13b745c6eb51f416af9b9e6d9e490d718c7ed361

I adjusted the configuration files, all of them run. (I haven't tested what's in the  `nacl_shootout` folder though)
