### PR TITLE
Handling undef flags

### DIFF
--- a/src/validator/handlers/shift_handler.cc
+++ b/src/validator/handlers/shift_handler.cc
@@ -132,9 +132,9 @@ void ShiftHandler::build_circuit(const x64asm::Instruction& instr, SymState& sta
     extended_src = state[dest];
 
   // If the shift is length 1, we do set the OF
-  //auto set_of = shift_amt[7][0] == SymBitVector::constant(8, 1);
+  auto set_of = shift_amt[7][0] == SymBitVector::constant(8, 1);
   // If the shift amount is too large, CF is undefined for SHL/SHR
-  //auto undef_cf = (shift_amt[7][0] >= SymBitVector::constant(8, dest.size()));
+  auto undef_cf = (shift_amt[7][0] >= SymBitVector::constant(8, dest.size()));
 
   // Do the shift and extract final value and CF/OF flags
   // Note that the computation of CF/OF depends on instruction variant
@@ -147,22 +147,17 @@ void ShiftHandler::build_circuit(const x64asm::Instruction& instr, SymState& sta
     state.set(dest, result);
 
     // If not too large, CF is the lsb of extended result
-    /*
     state.set(eflags_cf, undef_cf.ite(
                 SymBool::tmp_var(),
                 operand_nonzero.ite(temp_dest[0], state[eflags_cf])
-              ));*/
-    // TODO: improve precision
-    state.set(eflags_cf, SymBool::tmp_var());
+              ));
 
     // If shift is length 1, OF is MSB of *original* operand
-    // TODO: improve precision
-    state.set(eflags_of, SymBool::tmp_var());
-    /*
     state.set(eflags_of, set_of.ite(
                 extended_src[dest.size()],
-                state[eflags_of]
-              ));*/
+                // state[eflags_of]
+                operand_nonzero.ite(SymBool::tmp_var(), state[eflags_of])
+              ));
 
   } else if (!rotate && right && sign) {
     temp_dest = extended_src.s_shr(shift_amt);
@@ -171,16 +166,17 @@ void ShiftHandler::build_circuit(const x64asm::Instruction& instr, SymState& sta
     state.set(dest, result);
 
     // For SAR, CF is set so long as a shift happens
-    // TODO: improve precision
-    state.set(eflags_cf, SymBool::tmp_var());
-    /*
     state.set(eflags_cf, operand_nonzero.ite(
                 temp_dest[0],
                 state[eflags_cf]
-              ));*/
+              ));
 
-    // TODO: improve precision
-    state.set(eflags_of, SymBool::tmp_var());
+    // The OF bit is set to 0 if this is a shift of length 1, otherwise left alone
+    state.set(eflags_of, set_of.ite(
+                SymBool::_false(),
+                // state[eflags_of]
+                operand_nonzero.ite(SymBool::tmp_var(), state[eflags_of])
+              ));
 
   } else if (!rotate && !right) {
     temp_dest = extended_src << shift_amt;
@@ -189,44 +185,36 @@ void ShiftHandler::build_circuit(const x64asm::Instruction& instr, SymState& sta
     state.set(dest, result);
 
     // If not too large, CF is the msb of extended result
-    // TODO: improve precision
-    state.set(eflags_cf, SymBool::tmp_var());
-    /*
     state.set(eflags_cf, undef_cf.ite(
                 SymBool::tmp_var(),
                 operand_nonzero.ite(temp_dest[dest.size()], state[eflags_cf])
-              )); */
+              ));
 
     // The OF bit is 0 <=> MSB of result is same as carry flag (unless left alone)
-    // TODO: improve proceision
-    state.set(eflags_of, SymBool::tmp_var());
-    /*
     state.set(eflags_of, set_of.ite(
-                state[eflags_cf] != result[dest.size() - 1],
-                state[eflags_of]
-              ));*/
+                // state[eflags_cf] != result[dest.size() - 1],
+                //state[eflags_of]
+                state[eflags_cf] ^ result[dest.size() - 1],
+                operand_nonzero.ite(SymBool::tmp_var(), state[eflags_of])
+              ));
   } else if (rotate && !rotate_cf) {
 
     // Do the shift and store the result
-    //int last_bit_shifted;
+    int last_bit_shifted;
     if (right) {
       temp_dest = extended_src.ror(shift_amt);
-      //last_bit_shifted = dest.size() - 1;
+      last_bit_shifted = dest.size() - 1;
     } else {
       temp_dest = extended_src.rol(shift_amt);
-      //last_bit_shifted = 0;
+      last_bit_shifted = 0;
     }
     state.set(dest, temp_dest);
 
-    // If not too large, CF is the msb of extended result
-    // TODO: improve precision
-    state.set(eflags_cf, SymBool::tmp_var());
-    /*
     // Set CF to last bit rotated, if any
     state.set(eflags_cf, operand_nonzero.ite(
                 temp_dest[last_bit_shifted],
                 state[eflags_cf]
-              ));*/
+              ));
 
     // Set OF (if needed) to xor of two MSB (for right shifts)
     // or xor of MSB, LSB (for left shifts)
@@ -237,9 +225,10 @@ void ShiftHandler::build_circuit(const x64asm::Instruction& instr, SymState& sta
       of = temp_dest[dest.size() - 1] ^ temp_dest[0];
     }
 
-    // TODO: improve precision
-    state.set(eflags_of, SymBool::tmp_var());
-    //state.set(eflags_of, set_of.ite(of, SymBool::tmp_var()));
+    // state.set(eflags_of, set_of.ite(of, SymBool::tmp_var()));
+    state.set(eflags_of, set_of.ite(of,
+                                    operand_nonzero.ite(SymBool::tmp_var(), state[eflags_of])
+                                   ));
 
   } else if (rotate && rotate_cf) {
 
@@ -265,14 +254,12 @@ void ShiftHandler::build_circuit(const x64asm::Instruction& instr, SymState& sta
       of = temp_dest[dest.size() - 1] ^ temp_dest[dest.size() - 2];
     else
       of = temp_dest[dest.size()] ^ temp_dest[dest.size() - 1];
+    // SymBool of = temp_dest[dest.size() - 1] ^ state[eflags_cf];
 
-    // TODO: improve precision
-    state.set(eflags_of, SymBool::tmp_var());
-    /*
     state.set(eflags_of, set_of.ite(
                 of,
-                operand_nonzero.ite( state[eflags_of], SymBool::tmp_var())
-              ));*/
+                operand_nonzero.ite( SymBool::tmp_var(), state[eflags_of])
+              ));
   }
 
 

--- a/src/validator/handlers/simple_handler.cc
+++ b/src/validator/handlers/simple_handler.cc
@@ -310,10 +310,10 @@ void SimpleHandler::add_all() {
     ss.set(eflags_zf, SymBool::tmp_var());
     ss.set(eflags_af, SymBool::tmp_var());
     ss.set(eflags_pf, SymBool::tmp_var());
+    ss.set(eflags_sf, SymBool::tmp_var());
 
     ss.set(eflags_of, of);
     ss.set(eflags_cf, of);
-    ss.set(eflags_sf, res[n-1]);
   });
 
   add_opcode_str({"imulq", "imull", "imulw"},
@@ -333,10 +333,10 @@ void SimpleHandler::add_all() {
     ss.set(eflags_zf, SymBool::tmp_var());
     ss.set(eflags_af, SymBool::tmp_var());
     ss.set(eflags_pf, SymBool::tmp_var());
+    ss.set(eflags_sf, SymBool::tmp_var());
 
     ss.set(eflags_of, of);
     ss.set(eflags_cf, of);
-    ss.set(eflags_sf, res[n-1]);
   });
 
   add_opcode_str({"mulq", "mull", "mulw", "mulb"},
@@ -423,8 +423,8 @@ void SimpleHandler::add_all() {
     ss.set(eflags_zf, SymBool::tmp_var());
     ss.set(eflags_af, SymBool::tmp_var());
     ss.set(eflags_pf, SymBool::tmp_var());
+    ss.set(eflags_sf, SymBool::tmp_var());
 
-    ss.set(eflags_sf, full_res[n-1]);
     ss.set(eflags_of, of);
     ss.set(eflags_cf, of);
   });


### PR DESCRIPTION
- For the following 8 instructions, `sf` should be a `must undef` according to manual. This is corrected in the pull request.
  
 ```
  imulb_r8, imulb_rh, imull_r32, imull_r32_r32, imulq_r64, imulq_r64_r64,
    imulw_r16, imulw_r16_r16,
 ```


- For the following 40 instructions , modelling `af` flag is not supported yet. They are now supported in the pull request. 
  ```
  rclb_r8_cl, rclb_rh_cl, rcll_r32_cl, rclq_r64_cl, rclw_r16_cl, rcrb_r8_cl,
  rcrb_rh_cl, rcrl_r32_cl, rcrq_r64_cl, rcrw_r16_cl, rolb_r8_cl, rolb_rh_cl,
  roll_r32_cl, rolq_r64_cl, rolw_r16_cl, rorb_r8_cl, rorb_rh_cl, rorl_r32_cl,
  rorq_r64_cl, rorw_r16_cl, salb_r8_cl, salb_rh_cl, sall_r32_cl, salq_r64_cl,
  salw_r16_cl, sarb_r8_cl, sarb_rh_cl, sarl_r32_cl, sarq_r64_cl, sarw_r16_cl,
  shlb_r8_cl, shlb_rh_cl, shll_r32_cl, shlq_r64_cl, shlw_r16_cl, shrb_r8_cl,
  shrb_rh_cl, shrl_r32_cl, shrq_r64_cl, shrw_r16_cl
  ```
  For this case, I have tested with values which will not trigger the condition for `may undefs` (which make it possible to test against hardware) 
